### PR TITLE
new field mzh_travel added

### DIFF
--- a/solutions/travelsolution/Entities/mzh_travel/Entity.xml
+++ b/solutions/travelsolution/Entities/mzh_travel/Entity.xml
@@ -607,6 +607,46 @@
             <Description description="" languagecode="1033" />
           </Descriptions>
         </attribute>
+        <attribute PhysicalName="mzh_TravelWith">
+          <Type>nvarchar</Type>
+          <Name>mzh_travelwith</Name>
+          <LogicalName>mzh_travelwith</LogicalName>
+          <RequiredLevel>none</RequiredLevel>
+          <DisplayMask>ValidForAdvancedFind|ValidForForm|ValidForGrid</DisplayMask>
+          <ImeMode>auto</ImeMode>
+          <ValidForUpdateApi>1</ValidForUpdateApi>
+          <ValidForReadApi>1</ValidForReadApi>
+          <ValidForCreateApi>1</ValidForCreateApi>
+          <IsCustomField>1</IsCustomField>
+          <IsAuditEnabled>1</IsAuditEnabled>
+          <IsSecured>0</IsSecured>
+          <IntroducedVersion>1.0</IntroducedVersion>
+          <IsCustomizable>1</IsCustomizable>
+          <IsRenameable>1</IsRenameable>
+          <CanModifySearchSettings>1</CanModifySearchSettings>
+          <CanModifyRequirementLevelSettings>1</CanModifyRequirementLevelSettings>
+          <CanModifyAdditionalSettings>1</CanModifyAdditionalSettings>
+          <SourceType>0</SourceType>
+          <IsGlobalFilterEnabled>0</IsGlobalFilterEnabled>
+          <IsSortableEnabled>0</IsSortableEnabled>
+          <CanModifyGlobalFilterSettings>1</CanModifyGlobalFilterSettings>
+          <CanModifyIsSortableSettings>1</CanModifyIsSortableSettings>
+          <IsDataSourceSecret>0</IsDataSourceSecret>
+          <AutoNumberFormat></AutoNumberFormat>
+          <IsSearchable>0</IsSearchable>
+          <IsFilterable>0</IsFilterable>
+          <IsRetrievable>0</IsRetrievable>
+          <IsLocalizable>0</IsLocalizable>
+          <Format>text</Format>
+          <MaxLength>100</MaxLength>
+          <Length>200</Length>
+          <displaynames>
+            <displayname description="Travel With" languagecode="1033" />
+          </displaynames>
+          <Descriptions>
+            <Description description="" languagecode="1033" />
+          </Descriptions>
+        </attribute>
         <attribute PhysicalName="OverriddenCreatedOn">
           <Type>datetime</Type>
           <Name>overriddencreatedon</Name>

--- a/solutions/travelsolution/Other/Customizations.xml
+++ b/solutions/travelsolution/Other/Customizations.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ImportExportXml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OrganizationVersion="9.2.25084.131" OrganizationSchemaType="Standard" CRMServerServiceabilityVersion="9.2.25084.00131">
+<ImportExportXml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OrganizationVersion="9.2.25084.131" OrganizationSchemaType="Standard" CRMServerServiceabilityVersion="9.2.25084.00136">
   <Entities />
   <Roles />
   <Workflows />

--- a/solutions/travelsolution/Other/Solution.xml
+++ b/solutions/travelsolution/Other/Solution.xml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ImportExportXml version="9.2.25084.131" SolutionPackageVersion="9.2" languagecode="1033" generatedBy="CrmLive" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OrganizationVersion="9.2.25084.131" OrganizationSchemaType="Standard" CRMServerServiceabilityVersion="9.2.25084.00131">
+<ImportExportXml version="9.2.25084.131" SolutionPackageVersion="9.2" languagecode="1033" generatedBy="CrmLive" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OrganizationVersion="9.2.25084.131" OrganizationSchemaType="Standard" CRMServerServiceabilityVersion="9.2.25084.00136">
   <SolutionManifest>
     <UniqueName>travelsolution</UniqueName>
     <LocalizedNames>
       <LocalizedName description="Travel Solution" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.0.0</Version>
+    <Version>1.0.0.20</Version>
     <Managed>0</Managed>
     <Publisher>
       <UniqueName>mzh</UniqueName>

--- a/solutions/travelsolution/aiskillconfigs/ais_FormFillFieldOptOut_mzh_travel_mzh_travelwith/aiskillconfig.xml
+++ b/solutions/travelsolution/aiskillconfigs/ais_FormFillFieldOptOut_mzh_travel_mzh_travelwith/aiskillconfig.xml
@@ -1,0 +1,15 @@
+<aiskillconfig uniquename="ais_FormFillFieldOptOut_mzh_travel_mzh_travelwith">
+  <aiskill>FormFillFieldOptOut</aiskill>
+  <attribute>
+    <entityid.logicalname>mzh_travel</entityid.logicalname>
+    <logicalname>mzh_travelwith</logicalname>
+  </attribute>
+  <description>mzh_travel - Travel With Form fill opt out</description>
+  <entity>
+    <logicalname>mzh_travel</logicalname>
+  </entity>
+  <iscustomizable>1</iscustomizable>
+  <scope>1</scope>
+  <statecode>0</statecode>
+  <statuscode>1</statuscode>
+</aiskillconfig>


### PR DESCRIPTION
This pull request introduces a new field to the `mzh_travel` entity and updates solution metadata to reflect this addition. It also configures an AI skill opt-out for the new field. The most important changes are grouped below:

**Entity Schema Updates:**

* Added a new custom attribute `mzh_travelwith` (display name "Travel With") of type `nvarchar` to the `mzh_travel` entity, with a maximum length of 100 and other standard settings.

**AI Skill Configuration:**

* Added a new AI skill configuration file `ais_FormFillFieldOptOut_mzh_travel_mzh_travelwith/aiskillconfig.xml` to opt out the `mzh_travelwith` field from AI form fill suggestions.

**Solution Metadata Updates:**

* Updated `Solution.xml` and `Customizations.xml` to increment version numbers and reflect the new CRM server serviceability version, indicating the solution has been updated to include the new field and configuration. [[1]](diffhunk://#diff-b4c026e3decc8e4d54908376c36425393101193a895aad50187e91f42329f8b9L2-R9) [[2]](diffhunk://#diff-c590c53f87581db7a2815aeebdebe9741840588a6f1c2d2af2a353259c771d25L2-R2)